### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,18 +34,19 @@ this.server.post('/download', function(req,res){
     	  if(err) {
         		console.log(err);
     	  } else {
-          const { execSync } = require("child_process");
-          execSync(folderPath+"/convert.sh test.md", (error, stdout, stderr) => {
-            if (error) {
-              console.log(`error: ${error.message}`);
-              return;
-            }
-            if (stderr) {
-              console.log(`stderr: ${stderr}`);
-              return;
-            }
-            console.log(`stdout: ${stdout}`);
-          });;
+          const { execFileSync } = require("child_process");
+          const path = require("path");
+          try {
+            const output = execFileSync(
+              path.join(folderPath, "convert.sh"),
+              ["test.md"],
+              { encoding: "utf-8" }
+            );
+            console.log(`stdout: ${output}`);
+          } catch (error) {
+            console.log(`error: ${error.message}`);
+            return res.sendStatus(500);
+          }
           res.sendStatus(200);
         };
       });


### PR DESCRIPTION
Potential fix for [https://github.com/Shaneosaure/pandoc-as-a-service/security/code-scanning/1](https://github.com/Shaneosaure/pandoc-as-a-service/security/code-scanning/1)

The best way to fix this issue is to avoid constructing a shell command by concatenating the script path and file name into a single string for direct execution by the shell. Instead, use the child_process `execFileSync` method, which receives the program and its arguments separately and does not invoke the shell, preventing interpretation of path values with spaces or control characters.  
Specifically, replace the line:
```js
execSync(folderPath+"/convert.sh test.md", (error, stdout, stderr) => {
...
});
```
with code using `execFileSync`, where the first argument is the path to the executable, and the second argument is an array of its arguments, e.g.:
```js
execFileSync(path.join(folderPath, "convert.sh"), ["test.md"]);
```
You will need to require `path` and `execFileSync` from `child_process` at the top of the enclosing block (only if not already present in the context).  
All required code changes are on line 38 (and minor imports/definitions if required) in server.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
